### PR TITLE
Chown

### DIFF
--- a/helper/schema/provider_test.go
+++ b/helper/schema/provider_test.go
@@ -341,7 +341,7 @@ func TestProviderDiff_timeoutInvalidValue(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected provider.Diff to fail with invalid timeout value")
 	}
-	expectedErrMsg := "time: invalid duration invalid"
+	expectedErrMsg := "time: invalid duration \"invalid\""
 	if !strings.Contains(err.Error(), expectedErrMsg) {
 		t.Fatalf("Unexpected error message: %q\nExpected message to contain %q",
 			err.Error(),

--- a/internal/configs/configload/loader_snapshot.go
+++ b/internal/configs/configload/loader_snapshot.go
@@ -313,6 +313,10 @@ func (fs snapshotFS) Chmod(name string, mode os.FileMode) error {
 	return fmt.Errorf("cannot set file mode inside configuration snapshot")
 }
 
+func (fs snapshotFS) Chown(name string, uid, gid int) error {
+	return fmt.Errorf("cannot set file owner inside configuration snapshot")
+}
+
 func (fs snapshotFS) Chtimes(name string, atime, mtime time.Time) error {
 	return fmt.Errorf("cannot set file times inside configuration snapshot")
 }


### PR DESCRIPTION
Implement a snapshotFS.Chown method to comply with the new requirement
of the afero.Fs interface.

This change is required because the new Chown method has been added to
the Fs interface in v1.5.0 without a major version bump, thus making
Go's Minimal Version Selector breaking builds on upgrade